### PR TITLE
Timestamp getMilliseconds() support

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -72,7 +72,7 @@ func newProxy(l logging.Logger, name string, defs []internal.InterpretableDefini
 	l.Debug(name, fmt.Sprintf("%d postEvaluator(s) loaded", len(postEvaluators)))
 
 	return func(ctx context.Context, r *proxy.Request) (*proxy.Response, error) {
-		now := timeNow().Format(time.RFC3339)
+		now := timeNow().Format("2006-01-02T15:04:05.999Z07:00")
 
 		if err := evalChecks(l, name+"[pre]", newReqActivation(r, now), preEvaluators); err != nil {
 			return nil, err

--- a/rejecter.go
+++ b/rejecter.go
@@ -2,7 +2,6 @@ package cel
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/krakend/krakend-cel/v2/internal"
@@ -38,7 +37,7 @@ type Rejecter struct {
 }
 
 func (r *Rejecter) Reject(data map[string]interface{}) bool {
-	now := timeNow().Format(time.RFC3339)
+	now := timeNow().Format("2006-01-02T15:04:05.999Z07:00")
 	reqActivation := map[string]interface{}{
 		internal.JwtKey: data,
 		internal.NowKey: now,


### PR DESCRIPTION
Modifying the current timestamp with a format that CEL understands to properly extract the milliseconds.

### Example usage
```
timestamp(now).getMilliseconds() >= 500
```